### PR TITLE
util.pump() is deprecated. Use readableStream.pipe() instead.

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -161,8 +161,11 @@ function copyFile(source, dest, overwrite, callback) {
                 }
             }
 
-            nodeUtil.pump(fs.createReadStream(source),
-                    fs.createWriteStream(dest, {mode: 0655}), callback);
+          if(nodeUtil.pump){
+              nodeUtil.pump(fs.createReadStream(source), fs.createWriteStream(dest, {mode: 0655}), callback);
+          }else{
+              fs.createReadStream(source).on("end", callback).pipe(fs.createWriteStream(dest, {mode: 0655}));
+          }
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "auidocjs",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "AUIDoc from YUIDoc",
     "author": "hooriza <hooriza.nospam@gmail.com>",
     "bugs": { "url" : "http://github.com/hooriza/auidoc/issues" },


### PR DESCRIPTION
최신버전의 nodejs에서 util.pump() 메서드는 deprecated되었습니다. 해당 메서드가 없는 경우엔 Stream의 pipe() 메서드를 사용하도록 수정하였습니다.